### PR TITLE
Opencv 3.1.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cmake .. && make -j
 
 ###Usage
 ```
-./extract_gpu -f test.avi -x tmp/flow_x -y tmp/flow_y -i tmp/image -b 20 -t 1 -d 0 -s 1 -o dir
+./extract_gpu -f=test.avi -x=tmp/flow_x -y=tmp/flow_y -i=tmp/image -b=20 -t=1 -d=0 -s=1 -o=dir
 ```
 - `test.avi`: input video
 - `tmp`: folder containing RGB images and optical flow images

--- a/build_of.py
+++ b/build_of.py
@@ -44,7 +44,7 @@ def run_optical_flow(vid_item, dev_id=0):
     flow_x_path = '{}/flow_x'.format(out_full_path)
     flow_y_path = '{}/flow_y'.format(out_full_path)
 
-    cmd = './build/extract_gpu -f {} -x {} -y {} -i {} -b 20 -t 1 -d {} -s 1 -o zip'.format(vid_path, flow_x_path, flow_y_path, image_path, dev_id)
+    cmd = './build/extract_gpu -f={} -x={} -y={} -i={} -b=20 -t=1 -d={} -s=1 -o=zip'.format(vid_path, flow_x_path, flow_y_path, image_path, dev_id)
 
     os.system(cmd)
     print '{} {} done'.format(vid_id, vid_name)

--- a/include/common.h
+++ b/include/common.h
@@ -20,7 +20,7 @@ void convertFlowToImage(const Mat &flow_x, const Mat &flow_y, Mat &img_x, Mat &i
 void drawOptFlowMap(const Mat& flow, Mat& cflowmap, int step,double, const Scalar& color);
 
 void encodeFlowMap(const Mat& flow_map_x, const Mat& flow_map_y,
-                   vector<uchar>& encoded_x, vector<uchar>& encoded_y,
+                   std::vector<uchar>& encoded_x, std::vector<uchar>& encoded_y,
                    int bound);
 
 inline void initializeMats(const Mat& frame,
@@ -33,7 +33,7 @@ inline void initializeMats(const Mat& frame,
     prev_gray.create(frame.size(), CV_8UC1);
 }
 
-void writeImages(vector<vector<uchar>> images, string name_temp);
+void writeImages(std::vector<std::vector<uchar>> images, std::string name_temp);
 
 #endif //DENSEFLOW_COMMON_H_H
 

--- a/include/dense_flow.h
+++ b/include/dense_flow.h
@@ -7,18 +7,18 @@
 
 #include "common.h"
 
-void calcDenseFlow(string file_name, int bound, int type, int step,
-                   vector<vector<uchar> >& output_x,
-                   vector<vector<uchar> >& output_y,
-                   vector<vector<uchar> >& output_img);
-void calcDenseFlowGPU(string file_name, int bound, int type, int step, int dev_id,
-                      vector<vector<uchar> >& output_x,
-                      vector<vector<uchar> >& output_y,
-                      vector<vector<uchar> >& output_img);
+void calcDenseFlow(std::string file_name, int bound, int type, int step,
+                   std::vector<std::vector<uchar> >& output_x,
+                   std::vector<std::vector<uchar> >& output_y,
+                   std::vector<std::vector<uchar> >& output_img);
+void calcDenseFlowGPU(std::string file_name, int bound, int type, int step, int dev_id,
+                      std::vector<std::vector<uchar> >& output_x,
+                      std::vector<std::vector<uchar> >& output_y,
+                      std::vector<std::vector<uchar> >& output_img);
 
-void calcDenseFlowPureGPU(string file_name, int bound, int type, int step, int dev_id,
-                      vector<vector<uchar> >& output_x,
-                      vector<vector<uchar> >& output_y,
-                      vector<vector<uchar> >& output_img);
+void calcDenseFlowPureGPU(std::string file_name, int bound, int type, int step, int dev_id,
+                      std::vector<std::vector<uchar> >& output_x,
+                      std::vector<std::vector<uchar> >& output_y,
+                      std::vector<std::vector<uchar> >& output_img);
 
 #endif //DENSEFLOW_DENSE_FLOW_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -7,6 +7,6 @@
 
 #include "common.h"
 
-void writeZipFile(vector<vector<uchar> >& data, string name_temp, string archive_name);
+void writeZipFile(std::vector<std::vector<uchar> >& data, std::string name_temp, std::string archive_name);
 
 #endif //DENSEFLOW_UTILS_H

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -30,7 +30,7 @@ void drawOptFlowMap(const Mat& flow, Mat& cflowmap, int step,double, const Scala
 }
 
 void encodeFlowMap(const Mat& flow_map_x, const Mat& flow_map_y,
-                   vector<uchar>& encoded_x, vector<uchar>& encoded_y,
+                   std::vector<uchar>& encoded_x, std::vector<uchar>& encoded_y,
                    int bound){
     Mat flow_img_x(flow_map_x.size(), CV_8UC1);
     Mat flow_img_y(flow_map_y.size(), CV_8UC1);
@@ -42,7 +42,7 @@ void encodeFlowMap(const Mat& flow_map_x, const Mat& flow_map_y,
     imencode(".jpg", flow_img_y, encoded_y);
 }
 
-void writeImages(vector<vector<uchar>> images, string name_temp){
+void writeImages(std::vector<std::vector<uchar>> images, std::string name_temp){
     for (int i = 0; i < images.size(); ++i){
         char tmp[256];
         sprintf(tmp, "_%05d.jpg", i+1);

--- a/src/dense_flow.cpp
+++ b/src/dense_flow.cpp
@@ -3,10 +3,10 @@
 //
 #include "common.h"
 
-void calcDenseFlow(string file_name, int bound, int type, int step,
-                   vector<vector<uchar> >& output_x,
-                   vector<vector<uchar> >& output_y,
-                   vector<vector<uchar> >& output_img){
+void calcDenseFlow(std::string file_name, int bound, int type, int step,
+                   std::vector<std::vector<uchar> >& output_x,
+                   std::vector<std::vector<uchar> >& output_y,
+                   std::vector<std::vector<uchar> >& output_img){
 
     VideoCapture video_stream(file_name);
     CHECK(video_stream.isOpened())<<"Cannot open video stream \""
@@ -37,7 +37,7 @@ void calcDenseFlow(string file_name, int bound, int type, int step,
                                      0.702, 5, 10, 2, 7, 1.5,
                                      cv::OPTFLOW_FARNEBACK_GAUSSIAN );
 
-            vector<uchar> str_x, str_y, str_img;
+            std::vector<uchar> str_x, str_y, str_img;
             split(flow, flow_split);
             encodeFlowMap(flow_split[0], flow_split[0], str_x, str_y, bound);
             imencode(".jpg", capture_image, str_img);

--- a/src/dense_flow.cpp
+++ b/src/dense_flow.cpp
@@ -16,6 +16,7 @@ void calcDenseFlow(std::string file_name, int bound, int type, int step,
     Mat capture_frame, capture_image, prev_image, capture_gray, prev_gray;
     Mat flow, flow_split[2];
 
+    cv::Ptr<cv::DualTVL1OpticalFlow> alg_tvl1 = cv::createOptFlow_DualTVL1();
 
     bool initialized = false;
     for(int iter = 0;; iter++){
@@ -33,9 +34,24 @@ void calcDenseFlow(std::string file_name, int bound, int type, int step,
         }else if(iter % step == 0){
             capture_frame.copyTo(capture_image);
             cvtColor(capture_image, capture_gray, CV_BGR2GRAY);
-            calcOpticalFlowFarneback(prev_gray, capture_gray, flow,
-                                     0.702, 5, 10, 2, 7, 1.5,
-                                     cv::OPTFLOW_FARNEBACK_GAUSSIAN );
+
+            switch(type){
+                case 0: {
+                    calcOpticalFlowFarneback(prev_gray, capture_gray, flow,
+                                             0.702, 5, 10, 2, 7, 1.5,
+                                             cv::OPTFLOW_FARNEBACK_GAUSSIAN );
+                    break;
+                }
+                case 1: {
+                    alg_tvl1->calc(prev_gray, capture_gray, flow);
+                    break;
+                }
+                default:
+                    LOG(WARNING)<<"Unknown optical method. Using Farneback";
+                    calcOpticalFlowFarneback(prev_gray, capture_gray, flow,
+                                             0.702, 5, 10, 2, 7, 1.5,
+                                             cv::OPTFLOW_FARNEBACK_GAUSSIAN );
+            }
 
             std::vector<uchar> str_x, str_y, str_img;
             split(flow, flow_split);

--- a/src/dense_flow_gpu.cpp
+++ b/src/dense_flow_gpu.cpp
@@ -22,7 +22,6 @@ void calcDenseFlowGPU(std::string file_name, int bound, int type, int step, int 
     Mat flow_x, flow_y;
 
     GpuMat d_frame_0, d_frame_1;
-    //GpuMat d_flow_x, d_flow_y;
     GpuMat d_flow;
 
     cv::Ptr<cuda::FarnebackOpticalFlow> alg_farn = cuda::FarnebackOpticalFlow::create();
@@ -86,8 +85,6 @@ void calcDenseFlowGPU(std::string file_name, int bound, int type, int step, int 
             cuda::split(d_flow, planes);
 
             //get back flow map
-            //d_flow_x.download(flow_x);
-            //d_flow_y.download(flow_y);
             Mat flow_x(planes[0]);
             Mat flow_y(planes[1]);
 
@@ -130,7 +127,6 @@ void calcDenseFlowPureGPU(std::string file_name, int bound, int type, int step, 
     GpuMat capture_frame, capture_image, prev_image, capture_gray, prev_gray;
     Mat flow_x, flow_y, img;
 
-    //GpuMat d_flow_x, d_flow_y;
     GpuMat d_flow;
 
     cv::Ptr<cuda::FarnebackOpticalFlow> alg_farn = cuda::FarnebackOpticalFlow::create();
@@ -191,8 +187,6 @@ void calcDenseFlowPureGPU(std::string file_name, int bound, int type, int step, 
             //get back flow map
             Mat flow_x(planes[0]);
             Mat flow_y(planes[1]);
-            //d_flow_x.download(flow_x);
-            //d_flow_y.download(flow_y);
             capture_image.download(img);
 
             std::vector<uchar> str_x, str_y, str_img;

--- a/src/zip_utils.cpp
+++ b/src/zip_utils.cpp
@@ -5,7 +5,7 @@
 #include "utils.h"
 #include "zip.h"
 
-void writeZipFile(vector<vector<uchar> >& data, string name_temp, string archive_name){
+void writeZipFile(std::vector<std::vector<uchar> >& data, std::string name_temp, std::string archive_name){
     int err=0;
 #ifdef USE_OBSEL_LIBZIP
     struct zip* archive = zip_open(archive_name.c_str(), ZIP_CREATE, &err);

--- a/tools/extract_flow.cpp
+++ b/tools/extract_flow.cpp
@@ -17,15 +17,15 @@ int main(int argc, char** argv)
 		};
 
 	CommandLineParser cmd(argc, argv, keys);
-	string vidFile = cmd.get<string>("vidFile");
-	string xFlowFile = cmd.get<string>("xFlowFile");
-	string yFlowFile = cmd.get<string>("yFlowFile");
-	string imgFile = cmd.get<string>("imgFile");
-	string output_style = cmd.get<string>("out");
+	std::string vidFile = cmd.get<std::string>("vidFile");
+	std::string xFlowFile = cmd.get<std::string>("xFlowFile");
+	std::string yFlowFile = cmd.get<std::string>("yFlowFile");
+	std::string imgFile = cmd.get<std::string>("imgFile");
+	std::string output_style = cmd.get<std::string>("out");
 	int bound = cmd.get<int>("bound");
 
 //	LOG(INFO)<<"Starting extraction";
-	vector<vector<uchar> > out_vec_x, out_vec_y, out_vec_img;
+	std::vector<std::vector<uchar> > out_vec_x, out_vec_y, out_vec_img;
 
 	calcDenseFlow(vidFile, bound, 0, 1,
 					 out_vec_x, out_vec_y, out_vec_img);

--- a/tools/extract_flow.cpp
+++ b/tools/extract_flow.cpp
@@ -8,12 +8,12 @@ int main(int argc, char** argv)
 
 	const char* keys =
 		{
-			"{ f  | vidFile      | ex2.avi | filename of video }"
-			"{ x  | xFlowFile    | flow_x | filename of flow x component }"
-			"{ y  | yFlowFile    | flow_y | filename of flow x component }"
-			"{ i  | imgFile      | flow_i | filename of flow image}"
-			"{ b  | bound | 15 | specify the maximum of optical flow}"
-			"{ o  | out | zip | output style}"
+			"{ f vidFile   | ex2.avi | filename of video            }"
+			"{ x xFlowFile | flow_x  | filename of flow x component }"
+			"{ y yFlowFile | flow_y  | filename of flow x component }"
+			"{ i imgFile   | flow_i  | filename of flow image       }"
+			"{ b bound     | 15      | specify the maximum of optical flow}"
+			"{ o out       | zip     | output style                 }"
 		};
 
 	CommandLineParser cmd(argc, argv, keys);

--- a/tools/extract_flow.cpp
+++ b/tools/extract_flow.cpp
@@ -13,6 +13,7 @@ int main(int argc, char** argv)
 			"{ y yFlowFile | flow_y  | filename of flow x component }"
 			"{ i imgFile   | flow_i  | filename of flow image       }"
 			"{ b bound     | 15      | specify the maximum of optical flow}"
+			"{ t type      | 0       | specify the optical flow algorithm }"
 			"{ o out       | zip     | output style                 }"
 		};
 
@@ -23,11 +24,12 @@ int main(int argc, char** argv)
 	std::string imgFile = cmd.get<std::string>("imgFile");
 	std::string output_style = cmd.get<std::string>("out");
 	int bound = cmd.get<int>("bound");
+    int type  = cmd.get<int>("type");
 
 //	LOG(INFO)<<"Starting extraction";
 	std::vector<std::vector<uchar> > out_vec_x, out_vec_y, out_vec_img;
 
-	calcDenseFlow(vidFile, bound, 0, 1,
+	calcDenseFlow(vidFile, bound, type, 1,
 					 out_vec_x, out_vec_y, out_vec_img);
 
 	if (output_style == "dir") {

--- a/tools/extract_flow_gpu.cpp
+++ b/tools/extract_flow_gpu.cpp
@@ -3,7 +3,7 @@
 
 INITIALIZE_EASYLOGGINGPP
 
-using namespace cv::gpu;
+using namespace cv::cuda;
 
 int main(int argc, char** argv){
 	// IO operation
@@ -21,17 +21,17 @@ int main(int argc, char** argv){
 		};
 
 	CommandLineParser cmd(argc, argv, keys);
-	string vidFile = cmd.get<string>("vidFile");
-	string xFlowFile = cmd.get<string>("xFlowFile");
-	string yFlowFile = cmd.get<string>("yFlowFile");
-	string imgFile = cmd.get<string>("imgFile");
-	string output_style = cmd.get<string>("out");
+	std::string vidFile = cmd.get<std::string>("vidFile");
+	std::string xFlowFile = cmd.get<std::string>("xFlowFile");
+	std::string yFlowFile = cmd.get<std::string>("yFlowFile");
+	std::string imgFile = cmd.get<std::string>("imgFile");
+	std::string output_style = cmd.get<std::string>("out");
 	int bound = cmd.get<int>("bound");
     int type  = cmd.get<int>("type");
     int device_id = cmd.get<int>("device_id");
     int step = cmd.get<int>("step");
 
-	vector<vector<uchar> > out_vec_x, out_vec_y, out_vec_img;
+	std::vector<std::vector<uchar> > out_vec_x, out_vec_y, out_vec_img;
 
 	calcDenseFlowGPU(vidFile, bound, type, step, device_id,
 					 out_vec_x, out_vec_y, out_vec_img);

--- a/tools/extract_flow_gpu.cpp
+++ b/tools/extract_flow_gpu.cpp
@@ -9,15 +9,15 @@ int main(int argc, char** argv){
 	// IO operation
 	const char* keys =
 		{
-			"{ f  | vidFile      | ex2.avi | filename of video }"
-			"{ x  | xFlowFile    | flow_x | filename of flow x component }"
-			"{ y  | yFlowFile    | flow_y | filename of flow x component }"
-			"{ i  | imgFile      | flow_i | filename of flow image}"
-			"{ b  | bound | 15 | specify the maximum of optical flow}"
-			"{ t  | type | 0 | specify the optical flow algorithm }"
-			"{ d  | device_id    | 0  | set gpu id}"
-			"{ s  | step  | 1 | specify the step for frame sampling}"
-			"{ o  | out | zip | output style}"
+			"{ f vidFile   | ex2.avi | filename of video }"
+			"{ x xFlowFile | flow_x  | filename of flow x component }"
+			"{ y yFlowFile | flow_y  | filename of flow x component }"
+			"{ i imgFile   | flow_i  | filename of flow image}"
+			"{ b bound     | 15      | specify the maximum of optical flow}"
+			"{ t type      | 0       | specify the optical flow algorithm }"
+			"{ d device_id | 0       | set gpu id}"
+			"{ s step      | 1       | specify the step for frame sampling}"
+			"{ o out       | zip     | output style}"
 		};
 
 	CommandLineParser cmd(argc, argv, keys);


### PR DESCRIPTION
Hi @yjxiong, I've added support to OpenCV 3.1.0 for your code. The code still is basically the same, I only had to tweak a few function calls. The only thing I had to remove is the `VideoStream isOpened()` check, because it was dropped in 3.1.0 (in function `calcDenseFlowPureGPU`).

Maybe you would like to keep it in another branch, so you can provide support to both versions.
