### PR TITLE
For compatibility with opencv3.x issue#276

### DIFF
--- a/src/dense_flow.cpp
+++ b/src/dense_flow.cpp
@@ -5,6 +5,9 @@
 #include "dense_flow.h"
 #include "opencv2/optflow.hpp"
 
+using namespace cv;
+using namespace optflow;
+
 void calcDenseFlow(std::string file_name, int bound, int type, int step,
                    std::vector<std::vector<uchar> >& output_x,
                    std::vector<std::vector<uchar> >& output_y,
@@ -18,7 +21,9 @@ void calcDenseFlow(std::string file_name, int bound, int type, int step,
     Mat capture_frame, capture_image, prev_image, capture_gray, prev_gray;
     Mat flow, flow_split[2];
 
-    cv::Ptr<cv::optflow::DualTVL1OpticalFlow> alg_tvl1 = cv::optflow::DualTVL1OpticalFlow::create();
+    // For compatibility with opencv3.x 
+    Ptr<DenseOpticalFlow> alg_tvl1;
+    alg_tvl1 = createOptFlow_DualTVL1(); 
 
     bool initialized = false;
     for(int iter = 0;; iter++){


### PR DESCRIPTION
mentioned in https://github.com/yjxiong/temporal-segment-networks/issues/276
This is a contradiction: The build_all.sh install opencv 2.4.13.6, opencv 2.4.13.6 don't have opencv_contrib, so it surely will not have xfeatures2d. But dense_flow/src/dense_warp_flow_gpu.cpp needs xfeatures2d for compiling, so actually i have to modify the build_all.sh to install opencv3.x, not 2.x and changed the api format from 2.x to 3.x in dense_flow.cpp, accordingly